### PR TITLE
Kill subprocesses correctly on each platform on Ctrl-C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,8 +25,10 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "signal-hook",
  "structopt",
  "tempfile",
+ "tokio",
  "toml",
  "toml_edit",
  "winreg",
@@ -976,6 +978,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1153,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ command-group = "1.0.8"
 winreg = "0.10.1"
 
 [target.'cfg(unix)'.dependencies]
-tokio = { version = "1.18.2", features = ["sync", "process"] }
+tokio = { version = "1.18.2", features = ["macros", "sync", "process"] }
 signal-hook = "0.3.14"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.43"
 atty = "0.2.14"
-command-group = "1.0.8"
 dialoguer = "0.9.0"
 dirs = "3.0.2"
 env_logger = "0.9.0"
@@ -28,8 +27,13 @@ toml = "0.5.8"
 toml_edit = "0.14.4"
 zip = "0.5.13"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
+command-group = "1.0.8"
 winreg = "0.10.1"
+
+[target.'cfg(unix)'.dependencies]
+tokio = { version = "1.18.2", features = ["sync", "process"] }
+signal-hook = "0.3.14"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod home;
 mod ident;
 mod manifest;
+mod process;
 mod system_path;
 mod tool_alias;
 mod tool_id;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(windows)]
+mod windows;
+
+#[cfg(windows)]
+pub use windows::run;
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(unix)]
+pub use unix::run;

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -1,0 +1,57 @@
+//! On Unix, we use tokio to spawn processes so that we can listen for signals
+//! and wait for process completion at the same time.
+
+use std::path::Path;
+
+use signal_hook::consts::signals::{SIGABORT, SIGINT, SIGQUIT, SIGTERM};
+use signal_hook::iterator::Signals;
+use tokio::process::Command;
+use tokio::sync::oneshot;
+
+pub fn run(exe_path: &Path, args: Vec<String>) -> anyhow::Result<i32> {
+    let (kill_tx, kill_rx) = oneshot::channel();
+
+    // Spawn a thread dedicated to listening for signals and relaying them to
+    // our async runtime.
+    let (signal_thread, signal_handle) = {
+        let mut signals = Signals::new(&[SIGABORT, SIGINT, SIGQUIT, SIGTERM]).unwrap();
+        let signal_handle = signals.handle();
+
+        let thread = thread::spawn(move || {
+            for signal in &mut signals {
+                kill_tx.send(signal);
+                break;
+            }
+        });
+
+        (thread, signal_handle)
+    };
+
+    let mut child = Command::new(exe_path).args(args).spawn()?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread().build();
+    let code = runtime.block_on(async move {
+        tokio::select! {
+            // If the child exits cleanly, we can return its exit code directly.
+            // I wish everything were this tidy.
+            status = child.wait() => {
+                let code = status.ok().and_then(|s| s.code()).unwrap_or(1);
+                signal_handle.close();
+                signal_thread.join();
+
+                code
+            }
+
+            // If we received a signal while the process was running, murder it
+            // and exit immediately with the correct error code.
+            code = kill_rx => {
+                child.kill().await.ok();
+                signal_handle.close();
+                signal_thread.join();
+                std::process::exit(128 + code);
+            }
+        }
+    });
+
+    Ok(code)
+}

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -20,9 +20,8 @@ pub fn run(exe_path: &Path, args: Vec<String>) -> anyhow::Result<i32> {
         let signal_handle = signals.handle();
 
         let thread = thread::spawn(move || {
-            for signal in &mut signals {
+            if let Some(signal) = signals.into_iter().next() {
                 kill_tx.send(signal).ok();
-                break;
             }
         });
 

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -35,6 +35,7 @@ pub fn run(exe_path: &Path, args: Vec<String>) -> anyhow::Result<i32> {
         .with_context(|| format!("could not spawn {}", exe_path.display()))?;
 
     let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
         .build()
         .context("could not create tokio runtime")?;
 

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -29,15 +29,17 @@ pub fn run(exe_path: &Path, args: Vec<String>) -> anyhow::Result<i32> {
         (thread, signal_handle)
     };
 
-    let mut child = Command::new(exe_path)
-        .args(args)
-        .spawn()
-        .with_context(|| format!("could not spawn {}", exe_path.display()))?;
-
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .build()
         .context("could not create tokio runtime")?;
+
+    let _guard = runtime.enter();
+
+    let mut child = Command::new(exe_path)
+        .args(args)
+        .spawn()
+        .with_context(|| format!("could not spawn {}", exe_path.display()))?;
 
     let code = runtime.block_on(async move {
         tokio::select! {

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -1,0 +1,16 @@
+//! On Windows, we use command_group to spawn processes in a job group that will
+//! be automatically cleaned up when this process exits.
+
+use std::path::Path;
+use std::process::Command;
+
+use command_group::CommandGroup;
+
+pub fn run(exe_path: &Path, args: Vec<String>) -> anyhow::Result<i32> {
+    // On Windows, using a job group here will cause the subprocess to terminate
+    // automatically when Aftman is terminated.
+    let mut child = Command::new(exe_path).args(args).group_spawn()?;
+
+    let status = child.wait()?;
+    Ok(status.code().unwrap_or(1))
+}

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -4,12 +4,16 @@
 use std::path::Path;
 use std::process::Command;
 
+use anyhow::Context;
 use command_group::CommandGroup;
 
 pub fn run(exe_path: &Path, args: Vec<String>) -> anyhow::Result<i32> {
     // On Windows, using a job group here will cause the subprocess to terminate
     // automatically when Aftman is terminated.
-    let mut child = Command::new(exe_path).args(args).group_spawn()?;
+    let mut child = Command::new(exe_path)
+        .args(args)
+        .group_spawn()
+        .with_context(|| format!("Could not spawn {}", exe_path.display()))?;
 
     let status = child.wait()?;
     Ok(status.code().unwrap_or(1))

--- a/src/system_path/mod.rs
+++ b/src/system_path/mod.rs
@@ -5,7 +5,7 @@ mod windows;
 pub use windows::add;
 
 #[cfg(not(target_os = "windows"))]
-pub fn add(path: &std::path::Path) -> anyhow::Result<bool> {
+pub fn add(_path: &std::path::Path) -> anyhow::Result<bool> {
     log::debug!("Not adding value to path because this platform is not supported.");
     Ok(false)
 }


### PR DESCRIPTION
On Unix, process groups don't reap child processes when the parent process dies. Windows job groups do!

This PR introduces a separate code path for Unix systems that uses tokio's process API instead, and wires up a few signals to explicitly kill the child process.