### PR TITLE
Mark executables as executable on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Aftman Changelog
 
 ## Unreleased Changes
+* Aftman now correctly marks executables as executable on Unix platforms. ([#14])
+
+[#14]: https://github.com/LPGhatguy/aftman/pull/14
 
 ## [0.2.2] (May 23, 2022)
 * Fixed building on non-Windows platforms


### PR DESCRIPTION
Closes #11.

This was a straightforward fix.