### PR TITLE
Allow self-install to update running executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         rust_version: [stable, 1.58.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aftman"
 description = "Aftman is a command line toolchain manager"
 version = "0.2.4"
+rust-version = "1.58.0"
 license = "MIT"
 edition = "2021"
 repository = "https://github.com/LPGhatguy/aftman"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1.0.129", features = ["derive"] }
 serde_json = "1.0.67"
 structopt = "0.3.22"
+tempfile = "3.3.0"
 toml = "0.5.8"
 toml_edit = "0.14.4"
 zip = "0.5.13"

--- a/tests/snapshots/ui__self-install stderr.snap
+++ b/tests/snapshots/ui__self-install stderr.snap
@@ -4,5 +4,6 @@ assertion_line: 10
 expression: output.stderr
 ---
 [INFO  aftman::tool_storage] Updating all Aftman binaries...
+[INFO  aftman::tool_storage] Installing Aftman...
 [INFO  aftman::tool_storage] Updated Aftman binaries successfully!
 


### PR DESCRIPTION
Currently, running `aftman self-install` will always fail. This PR makes self-install do a bit more work to fix that.

It also enables updating running executables, as a nice side effect!