### PR TITLE
Support matching release labels including "darwin" for Apple platforms

### DIFF
--- a/src/tool_source/mod.rs
+++ b/src/tool_source/mod.rs
@@ -48,7 +48,10 @@ impl Asset {
             || match_name.contains("win64")
         {
             Some(OperatingSystem::Windows)
-        } else if match_name.contains("macos") || match_name.contains("osx") {
+        } else if match_name.contains("macos")
+            || match_name.contains("osx")
+            || match_name.contains("darwin")
+        {
             Some(OperatingSystem::MacOS)
         } else if match_name.contains("linux") || match_name.contains("ubuntu") {
             Some(OperatingSystem::Linux)


### PR DESCRIPTION
This PR fixes an issue that could occur with installing some tools which contain `darwin` but not `macos` nor `osx` in their release labels such as [rbxmk](https://github.com/Anaminus/rbxmk/).

This would fix the issue I had with installing rbxmk today, since macOS is sometimes referred to as "darwin".