### PR TITLE
Migrate to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.2.6"
 dependencies = [
  "anyhow",
  "atty",
+ "clap",
  "command-group",
  "dialoguer",
  "dirs",
@@ -27,7 +28,6 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
- "structopt",
  "tempfile",
  "test-util",
  "tokio",
@@ -44,15 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -143,17 +134,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -426,12 +441,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -711,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
@@ -759,6 +771,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "percent-encoding"
@@ -1054,33 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1137,12 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1329,12 +1320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,12 +1342,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 edition = "2021"
 repository = "https://github.com/LPGhatguy/aftman"
 readme = "README.md"
+authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 
 [workspace]
 members = ["test-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = ["test-util"]
 [dependencies]
 anyhow = "1.0.43"
 atty = "0.2.14"
+clap = { version = "3.2.17", features = ["derive"] }
 dialoguer = "0.9.0"
 dirs = "3.0.2"
 env_logger = "0.9.0"
@@ -24,7 +25,6 @@ reqwest = { version = "0.11.4", features = ["blocking"] }
 semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1.0.129", features = ["derive"] }
 serde_json = "1.0.67"
-structopt = "0.3.22"
 tempfile = "3.3.0"
 toml = "0.5.8"
 toml_edit = "0.14.4"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,7 @@ use std::env::current_dir;
 use std::path::PathBuf;
 
 use anyhow::{bail, Context};
-use structopt::StructOpt;
+use clap::Parser;
 
 use crate::home::Home;
 use crate::manifest::Manifest;
@@ -13,9 +13,10 @@ use crate::tool_spec::ToolSpec;
 use crate::tool_storage::{InstalledToolsCache, ToolStorage};
 use crate::trust::{TrustCache, TrustMode};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
+#[clap(version)]
 pub struct Args {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub subcommand: Subcommand,
 }
 
@@ -35,7 +36,7 @@ impl Args {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub enum Subcommand {
     Init(InitSubcommand),
     List(ListSubcommand),
@@ -48,7 +49,7 @@ pub enum Subcommand {
 }
 
 /// Initialize a new Aftman manifest file.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct InitSubcommand {
     /// The folder to initialize the manifest file in. Defaults to the current
     /// directory.
@@ -69,7 +70,7 @@ impl InitSubcommand {
 }
 
 /// Lists all existing tools managed by Aftman.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct ListSubcommand {}
 
 impl ListSubcommand {
@@ -106,7 +107,7 @@ impl ListSubcommand {
 }
 
 /// Adds a new tool to Aftman and installs it.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct AddSubcommand {
     /// A tool spec describing where to get the tool and what version to
     /// install.
@@ -117,7 +118,7 @@ pub struct AddSubcommand {
 
     /// Install this tool globally by adding it to ~/.aftman/aftman.toml instead
     /// of installing it to the nearest aftman.toml file.
-    #[structopt(long)]
+    #[clap(long)]
     pub global: bool,
 }
 
@@ -132,27 +133,27 @@ impl AddSubcommand {
 /// Tools can be specified either by their alias or by their name.
 ///
 /// If no tools are listed, Aftman will update all installed tools.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct UpdateSubcommand {
     /// One or more tools to update. If no tools are given, update all tools.
     pub aliases_or_specs: Vec<String>,
 
     /// Update this tool globally by adding it to ~/.aftman/aftman.toml instead
     /// of installing it to the nearest aftman.toml file that mentions it.
-    #[structopt(long)]
+    #[clap(long)]
     pub global: bool,
 
     /// Ignore semantic versioning and upgrade to the latest stable versions.
-    #[structopt(long)]
+    #[clap(long)]
     pub latest: bool,
 }
 
 /// Install all tools listed by Aftman files from the current directory.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct InstallSubcommand {
     /// Skip checking if these tools have been installed before. It is
     /// recommended to only run this on CI machines.
-    #[structopt(long)]
+    #[clap(long)]
     pub no_trust_check: bool,
 }
 
@@ -169,7 +170,7 @@ impl InstallSubcommand {
 }
 
 /// Mark the given tool name as being trusted.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct TrustSubcommand {
     /// The tool to mark as trusted.
     pub name: ToolName,
@@ -188,12 +189,12 @@ impl TrustSubcommand {
 }
 
 /// Update Aftman from the internet.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct SelfUpdateSubcommand {}
 
 /// Install Aftman and update all references to it. Run this command if you've
 /// just upgraded Aftman manually.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct SelfInstallSubcommand {}
 
 impl SelfInstallSubcommand {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,7 +14,7 @@ use crate::tool_storage::{InstalledToolsCache, ToolStorage};
 use crate::trust::{TrustCache, TrustMode};
 
 #[derive(Debug, Parser)]
-#[clap(version)]
+#[clap(author, version, about)]
 pub struct Args {
     #[clap(subcommand)]
     pub subcommand: Subcommand,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod trust;
 use std::env::{consts::EXE_SUFFIX, current_dir, current_exe};
 
 use anyhow::{bail, format_err, Context};
-use structopt::StructOpt;
+use clap::Parser;
 
 use crate::cli::Args;
 use crate::home::Home;


### PR DESCRIPTION
Fixes #15. 

Note that clap has colors enabled unlike structopt.