### PR TITLE
Trust check & installation improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "env_logger",
  "fs-err",
  "insta",
+ "itertools",
  "log",
  "once_cell",
  "reqwest",
@@ -579,9 +580,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dialoguer = "0.9.0"
 dirs = "3.0.2"
 env_logger = "0.9.0"
 fs-err = "2.6.0"
+itertools = "0.10.5"
 log = "0.4.14"
 once_cell = "1.9.0"
 reqwest = { version = "0.11.4", features = ["blocking"] }

--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ aftman add rojo-rbx/rojo@6.2.0 rojo6
 Usage:
 
 ```bash
-aftman install [--no-trust-check]
+aftman install [--no-trust-check] [--skip-untrusted]
 ```
 
 Install all tools listed in `aftman.toml` files based on your current directory.
 
 If `--no-trust-check` is given, all tools will be installed, regardless of whether they are known. This should generally only be used in CI environments. To trust a specific tool before running `aftman install`, use `aftman trust <tool>` instead.
+
+If `--skip-untrusted` is given, only already trusted tools will be installed, others will be skipped and not emit any errors.
 
 ### `aftman self-install`
 Usage:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -155,6 +155,9 @@ pub struct InstallSubcommand {
     /// recommended to only run this on CI machines.
     #[clap(long)]
     pub no_trust_check: bool,
+    /// Skip / don't error if a tool was not trusted during install.
+    #[clap(long)]
+    pub skip_untrusted: bool,
 }
 
 impl InstallSubcommand {
@@ -165,7 +168,7 @@ impl InstallSubcommand {
             TrustMode::Check
         };
 
-        tools.install_all(trust)
+        tools.install_all(trust, self.skip_untrusted)
     }
 }
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -13,6 +13,12 @@ pub enum TrustMode {
     NoCheck,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustStatus {
+    Trusted,
+    NotTrusted,
+}
+
 #[derive(Debug)]
 pub struct TrustCache {
     pub tools: BTreeSet<ToolName>,


### PR DESCRIPTION
In preparation of #26 and continuing on from my closed PR in #30, this PR refactors the `install_all` method to split trust checks from the installation process itself. This will allow tools to be installed concurrently in the future and also makes for a slightly improved user experience.

After the above work was done, adding the `--skip-untrusted` flag was trivial so I went ahead and also added that in this same PR, based on feedback comments in the previous PR.

Closes #6
Closes #17