### PR TITLE
Update create_new to create for zsh config

### DIFF
--- a/src/system_path/unix.rs
+++ b/src/system_path/unix.rs
@@ -55,11 +55,7 @@ fn append_line_if_not_present(path: &Path, line: &str, create: bool) -> anyhow::
         _ => false,
     };
 
-    let mut file = match OpenOptions::new()
-        .create_new(create)
-        .append(true)
-        .open(path)
-    {
+    let mut file = match OpenOptions::new().create(create).append(true).open(path) {
         Ok(file) => file,
         Err(err) => {
             if err.kind() != io::ErrorKind::NotFound {


### PR DESCRIPTION
This should fix #44 by changing `create_new` to `create`.

It seems like when for zsh only previously it was attempting to create a new file, but when the file already existed it fails with an [`AlreadyExists` error as it attempts to open](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#errors) when the file exists.

This is hard for me to test since I don't use zsh myself, I only encountered this helping others.