### PR TITLE
Strip upper-case version of EXE_SUFFIX

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,11 @@ fn current_exe_name() -> anyhow::Result<String> {
         .and_then(|name| name.to_str())
         .ok_or_else(|| format_err!("OS gave a funny result when asking for executable name"))?;
 
-    exe_name = exe_name.strip_suffix(EXE_SUFFIX).unwrap_or(exe_name);
+    exe_name = exe_name
+        .strip_suffix(EXE_SUFFIX)
+        // See https://github.com/LPGhatguy/aftman/issues/54: handle windows file extension case-insensitivity
+        .or_else(|| exe_name.strip_suffix(&EXE_SUFFIX.to_uppercase()))
+        .unwrap_or(exe_name);
 
     Ok(exe_name.to_owned())
 }


### PR DESCRIPTION
On windows, file paths are case insensitive, so `binary.EXE` should be treated just like `binary.exe`. Interestingly, command prompt will return a lowercase extension as the current exe name, whilst PowerShell does not. This fixes the case for PowerShell

Fixes #54