### PR TITLE
Add aarch64 builds to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             label: linux-x86_64
 
+          - host: linux
+            os: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
+            label: linux-aarch64
+
           - host: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -71,6 +76,14 @@ jobs:
           override: true
           profile: minimal
 
+      # No GHA runner for arm so need to cross-compile on x86
+      - name: Install arm build prerequisites
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install gcc-aarch64-linux-gnu
+          echo 'RUSTFLAGS=-C linker=aarch64-linux-gnu-gcc' >> "$GITHUB_ENV"
+
       - name: Build Release
         run: cargo build --release --locked --verbose --target ${{ matrix.target }}
         env:
@@ -81,6 +94,9 @@ jobs:
           # On platforms that use OpenSSL, ensure it is statically linked to
           # make binaries more portable.
           OPENSSL_STATIC: 1
+
+          # When building for arm, provide the linker for aarch64.
+          RUSTFLAGS: ${{ env.RUSTFLAGS }}
 
       - name: Create Release Archive
         shell: bash


### PR DESCRIPTION
Adds aarch64 to the build matrix. There's an additional step in the job which only runs on the aarch64 build to install the arm linker. This linker is passed to RUSTFLAGS during the build.

Successfully built for arm in my fork: https://github.com/jacksonwelsh/aftman/actions/runs/9152355436